### PR TITLE
fix a bug. Storage::Local::Mountpoint called with option that does not support

### DIFF
--- a/lib/omnistore/storage/local/mountpoint.rb
+++ b/lib/omnistore/storage/local/mountpoint.rb
@@ -65,16 +65,21 @@ module OmniStore
         end
 
         def move(src, dest, other = self, options = {})
+          force = options[:force]
+          opts = options.dup
+          opts.delete_if {|k, v| !FileUtils.have_option?(:mv, k)}
           src_path = expand(src)
           dest_path = expand(dest, other.dir)
-          FileUtils.mkdir_p(File.dirname(dest_path)) if options[:force]
-          FileUtils.mv(src_path, dest_path, options)
+          FileUtils.mkdir_p(File.dirname(dest_path)) if force
+          FileUtils.mv(src_path, dest_path, opts)
         end
 
         def copy(src, dest, other = self, options = {})
+          opts = options.dup
+          opts.delete_if {|k, v| !FileUtils.have_option?(:copy, k)}
           src_path = expand(src)
           dest_path = expand(dest, other.dir)
-          FileUtils.copy(src_path, dest_path, options)
+          FileUtils.copy(src_path, dest_path, opts)
         end
 
        private


### PR DESCRIPTION
Storage::Local::Mountpointに対して、FileUtilsがサポートしていないオプションを付けてメソッドを呼び出した場合に、エラーとなるバグを修正しました。
